### PR TITLE
feat: add HardhatUtils.reset

### DIFF
--- a/src/browser.test.ts
+++ b/src/browser.test.ts
@@ -21,10 +21,28 @@ beforeAll(async () => {
   utils = new HardhatUtils(env)
 })
 beforeEach(() => env.reset())
-afterEach(jest.restoreAllMocks)
 afterAll(() => env.close())
 
+const globalWithCy = global as typeof global & { cy: Cypress.cy }
+beforeAll(() => {
+  globalWithCy.cy = { task: jest.fn() as Cypress.cy['task'] } as Cypress.cy
+})
+
+beforeEach(jest.restoreAllMocks)
+
 describe('Hardhat', () => {
+  describe('reset', () => {
+    it('invokes hardhat:reset', () => {
+      return new Promise<void>((done) => {
+        jest.mocked(globalWithCy.cy.task).mockResolvedValueOnce(undefined)
+        utils.reset().then(() => {
+          expect(cy.task).toHaveBeenCalledTimes(1)
+          done()
+        })
+      })
+    })
+  })
+
   describe('account', () => {
     it('returns the first account', async () => {
       expect(utils.accounts[0]).toBe(utils.account)

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -70,6 +70,10 @@ export class HardhatUtils {
     })
   }
 
+  reset() {
+    return cy.task('hardhat:reset')
+  }
+
   /** The first account configured via hardhat - @see {@link accounts}. */
   get account() {
     return this.accounts[0]

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export async function setupHardhatEvents(on: Cypress.PluginEvents, config: Cypre
       chainId: env.chainId,
       accounts: env.accounts,
     }),
+    ['hardhat:reset']: () => env.reset(),
   })
   on('before:spec', () => env.reset())
   on('after:run', () => env.close())


### PR DESCRIPTION
Adds a `reset` method to `HardhatUtils`.

Cypress does not allow programmatic resets outside of `beforeAll` hooks, because it does not support events for `open` runs outside of browser open/close, so that this is necessary to allow users to reset the chain state between consecutive runs of the same spec.