### PR TITLE
feat: update mining time to reflect mainnet

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -9,6 +9,10 @@ const mainnetFork = {
 module.exports = {
   networks: {
     hardhat: {
+      mining: {
+        auto: false,
+        interval: 12000, // average mainnet block time
+      },
       chainId: 1,
       forking: mainnetFork,
       accounts: {


### PR DESCRIPTION
https://hardhat.org/hardhat-network/docs/explanation/mining-modes

I'm open to a shorter time to accelerate testing, or adding a util that runs `evm_mine` via rpc