### PR TITLE
build: continuous deployment

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,9 @@ name: Release
 
 on:
   workflow_dispatch: # manually
+  push: # continuous deployment
+    branches:
+      - main
 
 jobs:
   release:


### PR DESCRIPTION
Adds continuous deployment to the release workflow, such that any push to `main` is automatically released.