### PR TITLE
refactor: replace number with BigNumber in approval utils

### DIFF
--- a/src/browser/approval.test.ts
+++ b/src/browser/approval.test.ts
@@ -3,7 +3,7 @@
  * This is expected, and necessary in order collect coverage.
  */
 
-import { MaxUint160 } from '@uniswap/permit2-sdk'
+import { MaxUint160, MaxUint256 } from '@uniswap/permit2-sdk'
 import { Token } from '@uniswap/sdk-core'
 import { constants } from 'ethers/lib/ethers'
 
@@ -69,6 +69,12 @@ describe('Approval', () => {
       const updatedAllowance = await approval.getTokenAllowanceForPermit2({ owner, token })
       expect(updatedAllowance.eq(5)).toBeTruthy()
     })
+    it('approves max token allowance by default', async () => {
+      await approval.setTokenAllowanceForPermit2({ owner, token })
+
+      const allowance = await approval.getTokenAllowanceForPermit2({ owner, token })
+      expect(allowance).toMatchObject(MaxUint256)
+    })
     it('revokes USDT for Permit2', async () => {
       await approval.setTokenAllowanceForPermit2({ owner, token }, 5)
       await approval.revokeTokenAllowanceForPermit2({ owner, token })
@@ -98,7 +104,21 @@ describe('Approval', () => {
       await approval.setPermit2Allowance({ owner, token }, { amount: 5 })
 
       const updatedAllowance = await approval.getPermit2Allowance({ owner, token })
-      expect(updatedAllowance.expiration).toBeLessThanOrEqual(Date.now() / 1000 + 2_592_000)
+      expect(updatedAllowance.expiration).toBeLessThanOrEqual(Math.floor(Date.now() / 1000) + 2_592_000)
+    })
+    it('permits default amount/expiration when no approval is passed', async () => {
+      await approval.setPermit2Allowance({ owner, token })
+
+      const updatedAllowance = await approval.getPermit2Allowance({ owner, token })
+      expect(updatedAllowance.expiration).toBeLessThanOrEqual(Math.floor(Date.now() / 1000) + 2_592_000)
+      expect(updatedAllowance.amount).toMatchObject(MaxUint160)
+    })
+    it('permits default amount/expiration when empty object is passed', async () => {
+      await approval.setPermit2Allowance({ owner, token }, {})
+
+      const updatedAllowance = await approval.getPermit2Allowance({ owner, token })
+      expect(updatedAllowance.expiration).toBeLessThanOrEqual(Math.floor(Date.now() / 1000) + 2_592_000)
+      expect(updatedAllowance.amount).toMatchObject(MaxUint160)
     })
     it("revokes Universal Router's permit for USDT", async () => {
       await approval.setPermit2Allowance({ owner, token }, { amount: 5, expiration: 1000 })

--- a/src/browser/approval.ts
+++ b/src/browser/approval.ts
@@ -8,7 +8,7 @@ import { ImpersonatedSigner } from './signer'
 import { AddressLike } from './types'
 
 function get30DayExpiration(): number {
-  return Date.now() / 1000 + 2_592_000
+  return Math.floor(Date.now() / 1000) + 2_592_000
 }
 
 type ApprovalAddresses = { owner: AddressLike; token: AddressLike; spender: AddressLike }
@@ -98,7 +98,7 @@ export class ApprovalUtils {
    * */
   async setPermit2Allowance(
     { owner, token, spender = this.universalRouterAddress }: Permit2ApprovalAddresses,
-    { amount = MaxUint160, expiration = get30DayExpiration() }: { amount?: BigNumberish; expiration?: number }
+    { amount = MaxUint160, expiration = get30DayExpiration() } = {} as { amount?: BigNumberish; expiration?: number }
   ): Promise<void> {
     const addresses = normalizeApprovalAddresses({ owner, token, spender })
 


### PR DESCRIPTION
* updates `setTokenAllowance` to accept `BigNumberish` as input instead of `number`
* updates `setTokenAllowance` to use `MaxUint256` as default approval amount
* updates `setPermit2Allowance` to use `MaxUint160` as default approval amount & 30 days as default expiration time
* replaces usage of `BigNumber.from(0)` with `0`
* updates tests to match refactor