### PR TITLE
fix: reset providers when reseting fork

### DIFF
--- a/src/browser/provider.ts
+++ b/src/browser/provider.ts
@@ -1,6 +1,7 @@
 import { StaticJsonRpcProvider } from '@ethersproject/providers'
 
 export class HardhatProvider extends StaticJsonRpcProvider {
+  /** Resets internal state so that the block number may be "rewinded". */
   async reset() {
     // Reset all internal block number guards and caches.
     // See https://github.com/ethers-io/ethers.js/blob/v5/packages/providers/src.ts/base-provider.ts#L1168-L1175.

--- a/src/browser/utils.test.ts
+++ b/src/browser/utils.test.ts
@@ -239,21 +239,5 @@ describe('Utils', () => {
       expect(Number(latest.number)).toBe(Number(block.number) + 100)
       expect(Number(latest.timestamp)).toBe(Number(block.timestamp) + 42 * 100)
     })
-
-    it('updates providers immediately', async () => {
-      const { number: blockNumber } = await utils.send('eth_getBlockByNumber', ['latest', false])
-      // Wrap block event emission in a promise so the test will wait for it to resolve.
-      const emitsBlock = new Promise<void>((resolve) => {
-        const onBlock = (block: number) => {
-          if (block === Number(blockNumber) + 1) {
-            utils.provider.off('block', onBlock)
-            resolve()
-          }
-        }
-        utils.provider.on('block', onBlock)
-      })
-      await utils.mine()
-      await expect(emitsBlock).resolves.toBeUndefined()
-    })
   })
 })

--- a/src/browser/utils.ts
+++ b/src/browser/utils.ts
@@ -166,15 +166,6 @@ export class Utils {
     const { timestamp } = await this.send('eth_getBlockByNumber', ['latest', false])
     await this.send('evm_setNextBlockTimestamp', [hexValue(Number(timestamp) + blockInterval)])
     await this.send('hardhat_mine', [hexValue(count), hexValue(blockInterval)])
-    // Immediately update providers with the newly mined state.
-    await Promise.all(
-      this.providers.map(async (provider) => {
-        // Update the block number. poll() is debounced, but getBlockNumber() is not.
-        await provider.getBlockNumber()
-        // Emit the new block number. Only poll will emit a 'block' event.
-        await provider.poll()
-      })
-    )
   }
 
   /** Sends a JSON-RPC directly to hardhat. */


### PR DESCRIPTION
Fixes behavior around provider polling when a chain has been "reset".

- Resets providers to allow "rewinding" blocks when calling `Utils.reset()`
- Updates providers to latest block when calling `Utils.mine()`