### PR TITLE
fix: use default block number for mainnet

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -6,7 +6,6 @@ require('dotenv').config()
 const forks = {
   [ChainId.MAINNET]: {
     url: `https://mainnet.infura.io/v3/${process.env.INFURA_KEY}`,
-    blockNumber: 17023328,
     httpHeaders: { Origin: 'localhost:3000' },
   },
   [ChainId.POLYGON]: {


### PR DESCRIPTION
removes the custom block number form the hardhat forking config, so that the default behavior of the cypress plugin is to use the most recent block number. this is for mainnet only

https://hardhat.org/hardhat-network/docs/reference#forking

context: https://www.notion.so/uniswaplabs/hardhat-block-number-investigation-3d921d92a41049ad8a3a3bf329b20ae9


tested by building this change locally and installing the package into the `universe` repo, where i confirmed that the tests pass with no block numbers set


will rebase after #27  lands to fix CI~