### PR TITLE
fix: add joinDuplicateHeaders option to createServer

### DIFF
--- a/src/plugin/setup.ts
+++ b/src/plugin/setup.ts
@@ -121,7 +121,7 @@ export default async function setup(): Promise<
   const forwardingServer = http.createServer((req, res) => {
     // Forward responses to the active server.
     req.pipe(
-      http.request({ ...req, hostname: server.address, port: server.port }, (response) => {
+      http.request({ ...req, hostname: server.address, port: server.port, joinDuplicateHeaders: true }, (response) => {
         for (const header in response.headers) {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           res.setHeader(header, response.headers[header]!)


### PR DESCRIPTION
[Cypress doesn't allow us to set our own node version](https://github.com/cypress-io/cypress/issues/27016), and its getting run on > 18.16, causing cypress-hardhat to throw:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "options.joinDuplicateHeaders" property must be of type boolean. Received null
```

This adds the joinDuplicateHeaders field to avoid the above error so cypress-hardhat continues to work past 18.16